### PR TITLE
feat: switch CI review to npm-installed aictrl CLI

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -77,15 +77,15 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Setup Bun
+      - name: Setup Node
         if: steps.check_changes.outputs.skip != 'true'
-        uses: oven-sh/setup-bun@v2
+        uses: actions/setup-node@v4
         with:
-          bun-version: latest
+          node-version: 22
 
-      - name: Install Dependencies
+      - name: Install Aictrl CLI
         if: steps.check_changes.outputs.skip != 'true'
-        run: bun install --frozen-lockfile
+        run: npm install -g @aictrl/cli@latest
 
       - name: Run Aictrl Review
         if: steps.check_changes.outputs.skip != 'true'
@@ -96,7 +96,7 @@ jobs:
         run: |
           echo "Starting review with zai-coding-plan/glm-5 for PR #$PR_NUMBER SHA $PR_SHA..."
 
-          bun run --conditions=browser packages/cli/src/index.ts run --model zai-coding-plan/glm-5 "Review the changes in PR #$PR_NUMBER for the aictrl CLI.
+          aictrl run --model zai-coding-plan/glm-5 "Review the changes in PR #$PR_NUMBER for the aictrl CLI.
 
           **IMPORTANT**: This is a code review only. Do NOT run tests, npm commands, or build commands. Only read source files and git diffs.
 


### PR DESCRIPTION
## Summary

- Switches the CI code-review workflow from running `aictrl` directly from monorepo source (`bun run packages/cli/src/bin.ts`) to installing the published npm package (`npx @aictrl/cli`)
- Dogfoods the published `@aictrl/cli` npm package in our own CI pipeline, validating that the distributed package works correctly end-to-end
- Simplifies the workflow by removing the need to build the monorepo before running reviews

## Test plan

- [ ] Trigger a code-review workflow run on a test PR and verify `npx @aictrl/cli` installs and executes successfully
- [ ] Confirm review comments are posted correctly, matching previous behavior
- [ ] Verify no regressions in review quality or CI timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)