### PR TITLE
feat: emit tool_use events for subagent sessions

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -100,6 +100,7 @@ Emitted when a tool call completes (success or error). This includes tools execu
   "part": {
     "type": "tool",
     "tool": "bash",
+    "sessionID": "session_01abc...",
     "state": {
       "status": "completed",
       "input": { "command": "ls" },
@@ -111,18 +112,7 @@ Emitted when a tool call completes (success or error). This includes tools execu
 
 `state.status` is `"completed"` or `"error"`. On error, `state.error` contains the error message.
 
-When the tool was executed inside a subagent, the event includes additional fields:
-
-```json
-{
-  "type": "tool_use",
-  "part": { "..." },
-  "subagentSessionID": "session_01xyz...",
-  "parentSessionID": "session_01abc..."
-}
-```
-
-These fields are absent for tools executed in the primary session.
+For tools executed inside a subagent, `part.sessionID` will differ from the top-level `sessionID` — compare the two to identify subagent tool calls.
 
 ### `step_start` / `step_finish`
 

--- a/packages/cli/src/cli/cmd/run.ts
+++ b/packages/cli/src/cli/cmd/run.ts
@@ -446,7 +446,7 @@ export const RunCommand = cmd({
       const events = await sdk.event.subscribe()
       let error: string | undefined
       const startTime = Date.now()
-      const childSessions = new Map<string, { title: string }>()
+      const childSessions = new Set<string>()
 
       async function loop() {
         const toggles = new Map<string, boolean>()
@@ -476,7 +476,7 @@ export const RunCommand = cmd({
           if (event.type === "message.part.updated") {
             const part = event.properties.part
 
-            // Emit tool_use events for subagent sessions in JSON mode
+            // Skip non-primary session events, but emit tool_use for subagent sessions in JSON mode
             if (part.sessionID !== sessionID) {
               if (
                 args.format === "json" &&
@@ -484,11 +484,7 @@ export const RunCommand = cmd({
                 part.type === "tool" &&
                 (part.state.status === "completed" || part.state.status === "error")
               ) {
-                emit("tool_use", {
-                  part,
-                  subagentSessionID: part.sessionID,
-                  parentSessionID: sessionID,
-                })
+                emit("tool_use", { part })
               }
               continue
             }
@@ -599,7 +595,7 @@ export const RunCommand = cmd({
           if (event.type === "session.created") {
             const info = event.properties.info
             if (info.parentID === sessionID) {
-              childSessions.set(info.id, { title: info.title })
+              childSessions.add(info.id)
               emit("subagent_start", {
                 subagentSessionID: info.id,
                 parentSessionID: sessionID,


### PR DESCRIPTION
## Summary

- **Subagent `tool_use` events are now emitted** in NDJSON output (`--format json`). Previously they were silently dropped by the session ID filter.
- No new event fields needed — `part.sessionID` already identifies which session ran the tool. Consumers compare `part.sessionID` against the envelope `sessionID` to identify subagent tool calls.

## Test plan

- [x] Existing event race and error propagation tests pass
- [x] Existing skill event tests pass
- [x] Typecheck passes
- [ ] Manual: run with `--format json` and a prompt that triggers a subagent, verify `tool_use` events appear with `part.sessionID` differing from the envelope `sessionID`
- [ ] Manual: verify primary session `tool_use` events remain unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)