### PR TITLE
feat: add GLM-5.1 model support

### DIFF
--- a/packages/cli/src/provider/transform.ts
+++ b/packages/cli/src/provider/transform.ts
@@ -296,6 +296,7 @@ export namespace ProviderTransform {
     if (id.includes("gemini")) return 1.0
     if (id.includes("glm-4.6")) return 1.0
     if (id.includes("glm-4.7")) return 1.0
+    if (id.includes("glm-5")) return 1.0
     if (id.includes("minimax-m2")) return 1.0
     if (id.includes("kimi-k2")) {
       // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5
@@ -705,7 +706,7 @@ export namespace ProviderTransform {
 
     if (
       input.model.providerID === "baseten" ||
-      (input.model.providerID === "aictrl" && ["kimi-k2-thinking", "glm-4.6"].includes(input.model.api.id))
+      (input.model.providerID === "aictrl" && ["kimi-k2-thinking", "glm-4.6", "glm-5.1"].includes(input.model.api.id))
     ) {
       result["chat_template_args"] = { enable_thinking: true }
     }

--- a/packages/cli/test/tool/fixtures/models-api.json
+++ b/packages/cli/test/tool/fixtures/models-api.json
@@ -1747,6 +1747,23 @@
     "name": "Z.AI Coding Plan",
     "doc": "https://docs.z.ai/devpack/overview",
     "models": {
+      "glm-5.1": {
+        "id": "glm-5.1",
+        "name": "GLM-5.1",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": { "field": "reasoning_content" },
+        "temperature": true,
+        "knowledge": "2026-01",
+        "release_date": "2026-03-27",
+        "last_updated": "2026-03-27",
+        "modalities": { "input": ["text"], "output": ["text"] },
+        "open_weights": true,
+        "cost": { "input": 0, "output": 0, "cache_read": 0, "cache_write": 0 },
+        "limit": { "context": 204800, "output": 131072 }
+      },
       "glm-4.7": {
         "id": "glm-4.7",
         "name": "GLM-4.7",


### PR DESCRIPTION
## Summary
- Add temperature setting (1.0) for GLM-5.x models in `ProviderTransform.temperature()`
- Add GLM-5.1 to aictrl `chat_template_args` enable_thinking list
- Add GLM-5.1 model entry to test fixtures (`zai-coding-plan` provider)

## Test plan
- [x] All 103 transform tests pass
- [ ] Verify GLM-5.1 model loads correctly with `models.dev` API data

🤖 Generated with [Claude Code](https://claude.com/claude-code)