### PR TITLE
fix: protect config files from agent edit with default permission

### DIFF
--- a/packages/cli/src/agent/agent.ts
+++ b/packages/cli/src/agent/agent.ts
@@ -70,6 +70,13 @@ export namespace Agent {
         "*.env.*": "ask",
         "*.env.example": "allow",
       },
+      // protect config files from agent modification — prevents privilege escalation
+      // where the agent weakens its own permission rules for future sessions
+      edit: {
+        "*": "allow",
+        "*aictrl.jsonc": "ask",
+        "*aictrl.json": "ask",
+      },
     })
     const user = PermissionNext.fromConfig(cfg.permission ?? {})
 

--- a/packages/cli/test/permission/next.test.ts
+++ b/packages/cli/test/permission/next.test.ts
@@ -670,6 +670,61 @@ test("ask - checks all patterns and stops on first deny", async () => {
   })
 })
 
+// config file protection tests
+
+test("evaluate - config file patterns require ask for aictrl.jsonc", () => {
+  const ruleset = PermissionNext.fromConfig({
+    edit: {
+      "*": "allow",
+      "*aictrl.jsonc": "ask",
+      "*aictrl.json": "ask",
+    },
+  })
+  expect(PermissionNext.evaluate("edit", "aictrl.jsonc", ruleset).action).toBe("ask")
+  expect(PermissionNext.evaluate("edit", ".aictrl/aictrl.jsonc", ruleset).action).toBe("ask")
+})
+
+test("evaluate - config file patterns require ask for aictrl.json", () => {
+  const ruleset = PermissionNext.fromConfig({
+    edit: {
+      "*": "allow",
+      "*aictrl.jsonc": "ask",
+      "*aictrl.json": "ask",
+    },
+  })
+  expect(PermissionNext.evaluate("edit", "aictrl.json", ruleset).action).toBe("ask")
+  expect(PermissionNext.evaluate("edit", ".aictrl/aictrl.json", ruleset).action).toBe("ask")
+})
+
+test("evaluate - config file protection still allows normal file edits", () => {
+  const ruleset = PermissionNext.fromConfig({
+    edit: {
+      "*": "allow",
+      "*aictrl.jsonc": "ask",
+      "*aictrl.json": "ask",
+    },
+  })
+  expect(PermissionNext.evaluate("edit", "src/foo.ts", ruleset).action).toBe("allow")
+  expect(PermissionNext.evaluate("edit", "package.json", ruleset).action).toBe("allow")
+})
+
+test("evaluate - user config can override config file protection", () => {
+  const defaults = PermissionNext.fromConfig({
+    edit: {
+      "*": "allow",
+      "*aictrl.jsonc": "ask",
+      "*aictrl.json": "ask",
+    },
+  })
+  const user = PermissionNext.fromConfig({
+    edit: {
+      "*aictrl.jsonc": "allow",
+    },
+  })
+  const merged = PermissionNext.merge(defaults, user)
+  expect(PermissionNext.evaluate("edit", "aictrl.jsonc", merged).action).toBe("allow")
+})
+
 test("ask - allows all patterns when all match allow rules", async () => {
   await using tmp = await tmpdir({ git: true })
   await Instance.provide({


### PR DESCRIPTION
## Summary

- Adds default `edit: "ask"` permission rules for `*aictrl.jsonc` and `*aictrl.json` patterns in the hardcoded permission defaults
- Prevents agents from modifying their own permission config files without explicit user approval
- Closes a privilege escalation vector where an agent could weaken its restrictions for future sessions (permissions are cached at init, so the change wouldn't affect the current session but would persist for all future sessions)

## How it works

The hardcoded defaults in `agent.ts` are:
- Loaded once at process start, cached, never re-read
- Not modifiable by the agent (they're in code, not in a file)
- The lowest priority layer — user/managed config can still override them

In interactive mode, the user sees a permission prompt and can approve config edits. In headless mode, they're auto-rejected — preventing unattended privilege escalation.

## Changes

- `packages/cli/src/agent/agent.ts` — added `edit` rules to the `defaults` object
- `packages/cli/test/permission/next.test.ts` — added 4 tests covering config file protection, normal file passthrough, and user override

## Test plan

- [x] All 66 permission tests pass (4 new)
- [x] Config file patterns (`aictrl.jsonc`, `.aictrl/aictrl.json`, etc.) evaluate to `"ask"`
- [x] Normal file edits (`src/foo.ts`, `package.json`) still evaluate to `"allow"`
- [x] User config can override the default protection if desired

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)