### PR TITLE
fix: enable zai-coding-plan provider for glm-5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.1 (2026-04-03)
+
+### Fixes
+
+- **GLM-5.1 model support** — Added `zai-coding-plan` provider with custom loader and thinking config, enabling `glm-5.1` which is currently only available via the ZhipuAI CodingPlan API.
+
 ## 0.2.0 (2026-03-10)
 
 ### Features

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "name": "@aictrl/cli",
   "description": "Headless execution engine for AI agent skills",
   "type": "module",

--- a/packages/cli/src/provider/provider.ts
+++ b/packages/cli/src/provider/provider.ts
@@ -578,6 +578,15 @@ export namespace Provider {
         },
       }
     },
+    "zai-coding-plan": async () => {
+      const apiKey = Env.get("ZHIPU_API_KEY")
+      return {
+        autoload: !!apiKey,
+        options: {
+          apiKey,
+        },
+      }
+    },
   }
 
   export const Model = z

--- a/packages/cli/src/provider/transform.ts
+++ b/packages/cli/src/provider/transform.ts
@@ -711,7 +711,7 @@ export namespace ProviderTransform {
       result["chat_template_args"] = { enable_thinking: true }
     }
 
-    if (["zai", "zhipuai"].includes(input.model.providerID) && input.model.api.npm === "@ai-sdk/openai-compatible") {
+    if (["zai", "zai-coding-plan", "zhipuai"].includes(input.model.providerID) && input.model.api.npm === "@ai-sdk/openai-compatible") {
       result["thinking"] = {
         type: "enabled",
         clear_thinking: false,


### PR DESCRIPTION
## Summary

- GLM-5.1 is only available via ZhipuAI's CodingPlan API, not the regular ZAI API. Added a custom loader for the `zai-coding-plan` provider in `provider.ts` that reads `ZHIPU_API_KEY` from the environment.
- Included `zai-coding-plan` in the thinking transform config (`transform.ts`) so GLM-5.1 gets proper thinking mode support.
- Bumped version to 0.3.1 with a corresponding CHANGELOG entry.

## Test plan

- [x] Verify `zai-coding-plan` provider loads when `ZHIPU_API_KEY` is set
- [x] Verify `glm-5.1` model works end-to-end via the CodingPlan API
- [x] Confirm thinking mode is enabled for `zai-coding-plan` provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)