### PR TITLE
fix: refresh platform binary optionalDependencies on every release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,10 +89,20 @@ jobs:
 
             const distDir = path.join('dist', '@aictrl');
             const platformDeps = {};
-            for (const entry of fs.readdirSync(distDir)) {
-              const manifest = JSON.parse(
-                fs.readFileSync(path.join(distDir, entry, 'package.json'), 'utf8')
-              );
+            for (const entry of fs.readdirSync(distDir, { withFileTypes: true })) {
+              if (!entry.isDirectory()) continue;
+              const manifestPath = path.join(distDir, entry.name, 'package.json');
+              if (!fs.existsSync(manifestPath)) continue;
+              const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+              // Only accept packages that match the platform binary naming
+              // shape (@aictrl/cli-<linux|darwin|windows>-<arch>...). This
+              // guards against any non-binary subdirectory that may end up
+              // alongside them (e.g. the @aictrl/cli-ai wrapper that the
+              // legacy script/publish.ts creates) leaking into
+              // optionalDependencies.
+              if (typeof manifest.name !== 'string' || !/^@aictrl\/cli-(linux|darwin|windows)(-[a-z0-9]+)+$/.test(manifest.name)) {
+                continue;
+              }
               platformDeps[manifest.name] = manifest.version;
             }
             if (Object.keys(platformDeps).length === 0) {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,16 +46,31 @@ jobs:
         working-directory: packages/sdk
         run: bun pm pack && npm publish *.tgz --access public --provenance || true
 
-      - name: Publish @aictrl/cli-linux-x64
-        working-directory: packages/cli/dist/@aictrl/cli-linux-x64
-        run: npm publish --access public --provenance || true
+      - name: Publish platform binary packages
+        working-directory: packages/cli/dist/@aictrl
+        run: |
+          # Publish every @aictrl/cli-<platform>-<arch>[-variant] package that the
+          # build step produced. Each directory contains a generated package.json
+          # stamped with the release version. Individual failures (e.g. version
+          # already published on a rerun) are tolerated to match the convention
+          # used by the other publish steps in this workflow.
+          for dir in */; do
+            echo "Publishing ${dir%/}"
+            (cd "$dir" && npm publish --access public --provenance) || true
+          done
 
-      - name: Strip bundled deps from CLI package.json
+      - name: Strip bundled deps and refresh platform binary optionalDependencies
         working-directory: packages/cli
         run: |
-          # All dependencies are bundled into the compiled binary.
-          # Only optionalDependencies (platform binaries) are needed at install time.
+          # All bundleable dependencies are compiled into the native binary, so
+          # the published package only needs:
+          #   - platform binary packages (regenerated below from dist/ to match
+          #     the release version — otherwise stale pins ship the wrong binary)
+          #   - genuine runtime optionals like @parcel/watcher and bun-pty that
+          #     must be resolved at install time against the host platform
           node -e "
+            const fs = require('fs');
+            const path = require('path');
             const pkg = require('./package.json');
             delete pkg.dependencies;
             delete pkg.devDependencies;
@@ -64,7 +79,29 @@ jobs:
             delete pkg.overrides;
             delete pkg.exports;
             delete pkg.type;
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+
+            // Preserve non-platform-binary optionals (real runtime deps);
+            // drop any @aictrl/cli-* entries so we can repopulate from dist/.
+            const preserved = {};
+            for (const [name, version] of Object.entries(pkg.optionalDependencies || {})) {
+              if (!name.startsWith('@aictrl/cli-')) preserved[name] = version;
+            }
+
+            const distDir = path.join('dist', '@aictrl');
+            const platformDeps = {};
+            for (const entry of fs.readdirSync(distDir)) {
+              const manifest = JSON.parse(
+                fs.readFileSync(path.join(distDir, entry, 'package.json'), 'utf8')
+              );
+              platformDeps[manifest.name] = manifest.version;
+            }
+            if (Object.keys(platformDeps).length === 0) {
+              throw new Error('No platform binary packages found in ' + distDir);
+            }
+
+            pkg.optionalDependencies = { ...preserved, ...platformDeps };
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+            console.log('optionalDependencies:', pkg.optionalDependencies);
           "
 
       - name: Publish @aictrl/cli

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "packages/cli": {
       "name": "@aictrl/cli",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "bin": {
         "aictrl": "./bin/aictrl",
       },
@@ -124,7 +124,6 @@
         "zod-to-json-schema": "3.24.5",
       },
       "optionalDependencies": {
-        "@aictrl/cli-linux-x64": "0.2.0",
         "@parcel/watcher": "2.5.1",
         "bun-pty": "0.4.8",
       },
@@ -338,8 +337,6 @@
     "@ai-sdk/xai": ["@ai-sdk/xai@2.0.51", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.30", "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-AI3le03qiegkZvn9hpnpDwez49lOvQLj4QUBT8H41SMbrdTYOxn3ktTwrsSu90cNDdzKGMvoH0u2GHju1EdnCg=="],
 
     "@aictrl/cli": ["@aictrl/cli@workspace:packages/cli"],
-
-    "@aictrl/cli-linux-x64": ["@aictrl/cli-linux-x64@0.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2RZ/5E2wS5V6fDGoU/HwFjZwgH+gS7KBW7OXuB91NvwBbI085KTpjkShXbe78RrnJGiCX3Dr0kqpUTWB05BaaQ=="],
 
     "@aictrl/plugin": ["@aictrl/plugin@workspace:packages/plugin"],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -128,7 +128,6 @@
     "zod-to-json-schema": "3.24.5"
   },
   "optionalDependencies": {
-    "@aictrl/cli-linux-x64": "0.2.0",
     "@parcel/watcher": "2.5.1",
     "bun-pty": "0.4.8"
   },


### PR DESCRIPTION
## Summary

- The committed `@aictrl/cli` `optionalDependencies` hard-pinned `@aictrl/cli-linux-x64` to `0.2.0`, so `@aictrl/cli@0.3.0` and `@0.3.1` shipped pointing at the old `0.2.0` native binary — vanilla upgrades silently kept running the stale build.
- Only `@aictrl/cli-linux-x64` was even listed; `linux-arm64`, `darwin-*`, `windows-*`, and the musl/baseline variants were built by `script/build.ts` but neither published to npm nor referenced from the top-level `optionalDependencies`.
- The publish workflow now (1) loops over every platform binary the build produced under `packages/cli/dist/@aictrl/` and publishes each, and (2) regenerates `@aictrl/cli`'s `optionalDependencies` from those manifests at publish time, preserving genuine runtime optionals (`@parcel/watcher`, `bun-pty`) that the compiled binary still resolves at install time.
- Removed the stale `@aictrl/cli-linux-x64` entry from the committed `packages/cli/package.json` so the source-of-truth no longer lies about what ships.

## Why `@parcel/watcher` and `bun-pty` are preserved

The compiled Bun binary can't bundle these — `src/file/watcher.ts:38` does `require(\`@parcel/watcher-${process.platform}-${process.arch}-${libc}\`)` and `src/pty/index.ts:37` does `await import("bun-pty")`. Both are resolved against the host platform at runtime, so they must remain in the published `optionalDependencies`.

## Why the rewrite happens at publish time, not in source

`script/build.ts` already stamps each `dist/@aictrl/cli-<target>/package.json` with `Script.version` (the release tag), so it's the authoritative source for what binaries actually exist for this release. Reading from there guarantees the top-level package and the platform packages always agree on a version, with no manual bump step to forget.

If `dist/@aictrl/` is empty when the strip step runs, the script throws — fail loud rather than silently ship `@aictrl/cli` with no platform binaries.

## Test plan

- [x] Dry-ran the inline node rewrite script against a mocked `dist/@aictrl/` tree containing `cli-linux-x64`, `cli-linux-arm64`, `cli-darwin-arm64`, `cli-windows-x64-baseline`. Confirmed: stale `@aictrl/cli-linux-x64: 0.2.0` is replaced, `@parcel/watcher` and `bun-pty` are preserved, all 4 platform packages are added at the correct version, and stripped fields (`dependencies`/`devDependencies`/`peerDependencies`/`peerDependenciesMeta`/`overrides`/`exports`/`type`) are gone.
- [x] `python3 -c "yaml.safe_load(...)"` parses the updated workflow.
- [x] `bun turbo typecheck` clean (pre-push hook).
- [ ] **Real validation only happens on the next release** — the workflow only triggers on `release: published`. Recommend cutting a test tag (e.g. `v0.3.2-test.0`) against a scratch package first if you want belt-and-suspenders before the next user-facing release.
- [ ] After merge + next release: `npm view @aictrl/cli@<new-version>` should show all platform binaries in `optionalDependencies` at the matching version, and a fresh `npm install -g @aictrl/cli` on linux-x64 should pull `@aictrl/cli-linux-x64@<new-version>` (not 0.2.0).

## Out of scope (worth separate cleanup)

- `packages/cli/script/postinstall.mjs:52` uses the unscoped name `aictrl-${platform}-${arch}` while published packages are scoped `@aictrl/cli-*`. It silently no-ops on failure (`process.exit(0)` on line 130) and `bin/aictrl` does the real resolution correctly using the scoped name, so this is latent rather than user-facing — but should be fixed.
- `packages/cli/script/publish.ts` appears to be dead code (publishes as `@aictrl/cli-ai`, not invoked by any workflow). Could probably be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)