### PR TITLE
chore: bump @aictrl/cli to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.2 (2026-04-11)
+
+### Fixes
+
+- **Platform binary `optionalDependencies` regenerated at publish time** — `@aictrl/cli@0.3.0` and `@0.3.1` shipped with `@aictrl/cli-linux-x64` hard-pinned to `0.2.0`, so vanilla upgrades silently kept running the stale native binary. The publish workflow now publishes every platform binary the build produces (linux/darwin/windows × x64/arm64 × musl/baseline variants) and regenerates `@aictrl/cli`'s `optionalDependencies` from those manifests at release time, while preserving genuine runtime optionals (`@parcel/watcher`, `bun-pty`). (#46)
+
 ## 0.3.1 (2026-04-03)
 
 ### Fixes

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "packages/cli": {
       "name": "@aictrl/cli",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "bin": {
         "aictrl": "./bin/aictrl",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "name": "@aictrl/cli",
   "description": "Headless execution engine for AI agent skills",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bumps `@aictrl/cli` to 0.3.2
- First release that picks up the platform binary `optionalDependencies` fix from #46 — `@aictrl/cli@0.3.0` and `@0.3.1` both shipped on npm pointing at the stale `@aictrl/cli-linux-x64@0.2.0` native binary and need to be superseded
- Refreshes `bun.lock` (avoids the `--frozen-lockfile` failure that previous bumps left for the next release to discover)
- Adds CHANGELOG entry crediting #46

## Test plan

- [x] `bun turbo typecheck` clean (pre-push hook)
- [ ] CI green
- [ ] After merge, cut release `v0.3.2` to fire `publish.yml`
- [ ] After publish: `npm view @aictrl/cli@0.3.2 optionalDependencies` should list **all 11** platform binary packages at `0.3.2`, not just `@aictrl/cli-linux-x64`, and not at `0.2.0`
- [ ] `npm install -g @aictrl/cli@0.3.2` on linux-x64 should pull `@aictrl/cli-linux-x64@0.3.2` (verify via `npm ls -g @aictrl/cli-linux-x64`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)