### PR TITLE
fix: activate pinned npm via corepack in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,21 @@ jobs:
         with:
           node-version: 22
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+      - name: Activate pinned npm via corepack for OIDC trusted publishing
+        # npm's OIDC trusted publishing support requires npm >= 11.5.0, but the
+        # runner's bundled npm (10.9.x) is older. Previously this step ran
+        # `npm install -g npm@latest`, which self-corrupted on the runner's
+        # prebuilt tree and produced MODULE_NOT_FOUND for promise-retry —
+        # silently breaking every release since v0.3.1.
+        #
+        # Corepack ships with Node 22 and installs package managers to its
+        # own shim directory, sidestepping the self-upgrade corruption path
+        # entirely. Pinning to a specific version stops tracking a moving
+        # target that has historically shipped regressions.
+        run: |
+          corepack enable
+          corepack prepare npm@11.5.2 --activate
+          npm --version
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Summary

- The publish workflow has been silently failing since v0.3.1 (2026-04-03). `npm install -g npm@latest` self-corrupts on the runner's prebuilt npm tree, leaving `@npmcli/arborist`'s dependency graph half-replaced and the new binary crashing on first invocation with `MODULE_NOT_FOUND: promise-retry`. Result: the step exits 1 about 3 seconds in, the entire workflow aborts, and nothing gets published.
- Discovered while trying to release v0.3.2 (to ship the fix from #46): run [24284923898](https://github.com/aictrl-dev/cli/actions/runs/24284923898) failed at this step. Pulled the log, confirmed the error, then checked `npm view @aictrl/cli versions` — tops out at **`0.3.0`**. Neither v0.3.1 nor v0.3.2 is actually on npm; the GitHub release tags exist but their publish workflows both failed identically.
- This is why users reporting the stale `@aictrl/cli-linux-x64@0.2.0` pin hadn't seen the fix even after the CHANGELOG updates — the fix couldn't reach them because no release since `0.3.0` has actually been published.

## The fix

Replace `npm install -g npm@latest` with `corepack prepare npm@11.5.2 --activate`.

- **Why corepack instead of pinning `npm install -g`**: The failure mode is the self-upgrade mechanism itself, not any specific npm version. Corepack ships with Node 22, installs package managers to its own shim directory, and prepends them to `PATH` — it never touches the runner's bundled npm tree, so the MODULE_NOT_FOUND failure mode is unreachable.
- **Why `npm@11.5.2`**: OIDC trusted publishing support lands in npm `11.5.0`. `11.5.2` is that plus two patch releases — fresh enough to have all the functionality, old enough for initial regressions to have surfaced. Explicit pin instead of `@latest` stops tracking a moving target that has historically shipped the very corruption this PR fixes.
- **Added `npm --version` print** so future debugging has an obvious breadcrumb in the log.

## Follow-up after merge

Going to delete and re-cut the v0.3.2 release (the current v0.3.2 tag points at `02d828f`, which has the broken `publish.yml`; re-cutting from the new merge commit picks up the corepack fix). I'll handle that immediately after this merges, along with verifying `npm view @aictrl/cli@0.3.2 optionalDependencies` shows the full expanded platform binary map.

## Test plan

- [x] `bun turbo typecheck` clean (pre-push hook)
- [x] YAML parses (`python3 -c "yaml.safe_load(...)"`)
- [ ] CI green on this PR
- [ ] Re-cut v0.3.2 after merge; publish workflow run lands green
- [ ] `npm view @aictrl/cli@0.3.2` lists **0.3.2** as a published version (not just 0.3.0)
- [ ] `npm view @aictrl/cli@0.3.2 optionalDependencies` shows all 11 platform binaries at 0.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)