### PR TITLE
fix: pin publish workflow npm to 11.10.1 (pre promise-retry removal)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,20 +21,24 @@ jobs:
         with:
           node-version: 22
 
-      - name: Activate pinned npm via corepack for OIDC trusted publishing
-        # npm's OIDC trusted publishing support requires npm >= 11.5.0, but the
-        # runner's bundled npm (10.9.x) is older. Previously this step ran
-        # `npm install -g npm@latest`, which self-corrupted on the runner's
-        # prebuilt tree and produced MODULE_NOT_FOUND for promise-retry —
-        # silently breaking every release since v0.3.1.
+      - name: Upgrade npm to 11.10.1 for OIDC trusted publishing
+        # OIDC trusted publishing (auto-auth via GitHub Actions id-token) is
+        # supported from npm >= 11.5.0, so the runner's bundled npm (10.9.x)
+        # is too old and must be upgraded.
         #
-        # Corepack ships with Node 22 and installs package managers to its
-        # own shim directory, sidestepping the self-upgrade corruption path
-        # entirely. Pinning to a specific version stops tracking a moving
-        # target that has historically shipped regressions.
+        # Must be pinned below 11.11.0. In 11.11.0 (npm/cli#9008) the
+        # `promise-retry` dep was replaced with `@gar/promise-retry`, and
+        # installing that version over the runner's bundled 10.9.x tree
+        # leaves orphaned arborist files still `require('promise-retry')`,
+        # producing MODULE_NOT_FOUND and silently breaking every release
+        # since v0.3.1. Pinning to 11.10.1 (last version with `promise-retry`)
+        # avoids the removal boundary entirely.
+        #
+        # Corepack's `--activate` was tried (0837d45) but left the on-PATH
+        # npm at the runner's bundled 10.9.7, so OIDC auth never engaged
+        # and every publish failed with ENEEDAUTH.
         run: |
-          corepack enable
-          corepack prepare npm@11.5.2 --activate
+          npm install -g npm@11.10.1
           npm --version
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Third (and hopefully final) attempt to unbreak the publish workflow. Supersedes the corepack approach from #48 — that didn't actually work, and investigating why led to the real root cause.

## What #48 missed

`corepack prepare npm@11.5.2 --activate` + `npm --version` in the [publish run 24291470000 log](https://github.com/aictrl-dev/cli/actions/runs/24291470000) reported `10.9.7`, not `11.5.2`. Corepack's npm support is effectively inert for `--activate` — it stages the version in its cache but doesn't place it on `PATH` ahead of the runner's bundled npm. Net result: every `npm publish` in the workflow ran under the runner's bundled **10.9.7**, which pre-dates OIDC trusted publishing (added in 11.5.0), so none of the publishes auth'd. Everything failed with `ENEEDAUTH` — but `@aictrl/util`, `@aictrl/plugin`, `@aictrl/sdk`, and the platform binary loop all had `|| true` masking the failure, so only the final `Publish @aictrl/cli` step surfaced it as a workflow error. Verified: `npm view @aictrl/cli versions` still tops out at 0.3.0; nothing was published.

## Root cause of the original corruption

Why did `npm install -g npm@latest` in the pre-existing workflow start failing in the first place? In [npm/cli#9008](https://github.com/npm/cli/pull/9008), shipped in **npm 11.11.0** (2026-02-25), the `promise-retry` dep was removed and replaced with `@gar/promise-retry`. When a version ≥11.11.0 is installed globally over the runner's bundled 10.9.x npm tree, some arborist files from the old tree survive the install, and those files still do `require('promise-retry')` — which no longer exists. First invocation: `MODULE_NOT_FOUND: promise-retry`.

Why did v0.3.0 (2026-03-27) publish successfully? Bundled npm on that day's runner image was **10.9.4**. On April 3+, the runner's bundled npm was **10.9.3** and then **10.9.7**. The orphan behavior differs subtly between these base versions — 10.9.4 happened to get cleanly replaced. **So v0.3.0 worked by pure coincidence.** Every release attempt since April 3 (v0.3.1, both v0.3.2 attempts today) hit the corruption.

## The fix

Replace `corepack prepare npm@11.5.2 --activate` with `npm install -g npm@11.10.1`. Reasoning:

- **11.10.1 is the last npm release before 11.11.0** — no promise-retry removal, no orphan corruption during self-install
- **11.10.1 ≥ 11.5.0** — has OIDC trusted publishing, so the existing \`id-token: write\` + \`environment: release\` trusted-publisher configuration on npmjs.com auto-auths
- **Uses the same `npm install -g` mechanism** that v0.3.0 successfully used — not experimental corepack paths
- **Pinned explicitly** — no more moving-target breakage from \`@latest\` shipping future dep-tree changes

The forensic trail lives in a comment on the step itself so whoever debugs this next doesn't have to re-derive the 11.11.0 boundary from git history.

## Test plan

- [x] `bun turbo typecheck` clean (pre-push hook)
- [x] YAML parses
- [ ] CI green on this PR
- [ ] After merge, delete the current v0.3.2 tag and release (pointing at 8cd793c which still has the broken corepack workflow), re-cut v0.3.2 against the merge commit of this PR
- [ ] New publish workflow run completes successfully
- [ ] `npm view @aictrl/cli versions` includes **0.3.2** for the first time
- [ ] `npm view @aictrl/cli@0.3.2 optionalDependencies` shows all 11 platform binaries at 0.3.2 — this is the actual user-visible bug from #46 that we've been trying to release for hours

## Out of scope

- The `|| true` masking on publish steps hid the ENEEDAUTH cascade and made #48 look like a partial success when it was a total failure. The right follow-up is to make those steps fail-loud on auth errors while still tolerating "version already published" errors on re-runs. Not doing it in this PR because this PR needs to ship with the minimum possible diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)