### PR TITLE
ci: fail loud on npm publish errors that aren't EPUBLISHCONFLICT (#51)

### DIFF
--- a/.github/scripts/publish-if-new.sh
+++ b/.github/scripts/publish-if-new.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# publish-if-new.sh — pack-then-publish wrapper for the publish workflow.
+#
+# Tolerates ONLY "version already published" errors so reruns after a
+# partial failure still succeed. Every other error (ENEEDAUTH, network,
+# etc) fails loud. See issue #51 for the v0.3.1 / v0.3.2 silent-failure
+# post-mortem that motivated this wrapper.
+#
+# Usage:
+#   .github/scripts/publish-if-new.sh <package-label>
+#
+# Must be run from the package's working directory (where bun pm pack
+# will produce the .tgz). The <package-label> is used only for log
+# annotations (e.g. "@aictrl/util").
+
+set -euo pipefail
+
+label="${1:?Usage: publish-if-new.sh <package-label>}"
+
+# Clean stale tarballs so we always publish the freshly packed one.
+rm -f *.tgz
+
+bun pm pack
+
+# Use nullglob array to avoid pipefail exit on no matches (ls *.tgz
+# returns exit 2 when nothing matches, which pipefail propagates).
+shopt -s nullglob
+tarballs=(*.tgz)
+shopt -u nullglob
+
+if [ ${#tarballs[@]} -eq 0 ]; then
+  echo "::error::bun pm pack produced no .tgz files in $(pwd)"
+  exit 1
+fi
+
+if [ ${#tarballs[@]} -gt 1 ]; then
+  echo "::warning::bun pm pack produced ${#tarballs[@]} .tgz files in $(pwd), publishing first: ${tarballs[0]}"
+fi
+
+tarball="${tarballs[0]}"
+
+set +e
+output=$(npm publish "$tarball" --access public --provenance 2>&1)
+code=$?
+set -e
+
+echo "$output"
+
+if [ $code -ne 0 ]; then
+  if echo "$output" | grep -qE 'EPUBLISHCONFLICT|E409|cannot publish over|already published'; then
+    echo "::notice::Tolerating 'already published' error for ${label}"
+  else
+    exit $code
+  fi
+fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,27 +53,107 @@ jobs:
 
       - name: Publish @aictrl/util
         working-directory: packages/util
-        run: bun pm pack && npm publish *.tgz --access public --provenance || true
+        run: |
+          # Pack, then publish the resulting tarball. We tolerate ONLY the
+          # "version already published" error (EPUBLISHCONFLICT / E409 /
+          # "cannot publish over" / "already published") so reruns after a
+          # partial failure still succeed. Every other error - ENEEDAUTH,
+          # network, etc - must fail loud. See issue #51 for the v0.3.1 /
+          # v0.3.2 silent-failure post-mortem that motivated this wrapper.
+          bun pm pack
+          tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
+          if [ -z "$tarball" ]; then
+            echo "::error::bun pm pack produced no .tgz files in $(pwd)"
+            exit 1
+          fi
+          set +e
+          output=$(npm publish "$tarball" --access public --provenance 2>&1)
+          code=$?
+          set -e
+          echo "$output"
+          if [ $code -ne 0 ]; then
+            if echo "$output" | grep -qE 'EPUBLISHCONFLICT|E409|cannot publish over|already published'; then
+              echo "::notice::Tolerating 'already published' error for @aictrl/util"
+            else
+              exit $code
+            fi
+          fi
 
       - name: Publish @aictrl/plugin
         working-directory: packages/plugin
-        run: bun pm pack && npm publish *.tgz --access public --provenance || true
+        run: |
+          # See @aictrl/util step for wrapper rationale (issue #51).
+          bun pm pack
+          tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
+          if [ -z "$tarball" ]; then
+            echo "::error::bun pm pack produced no .tgz files in $(pwd)"
+            exit 1
+          fi
+          set +e
+          output=$(npm publish "$tarball" --access public --provenance 2>&1)
+          code=$?
+          set -e
+          echo "$output"
+          if [ $code -ne 0 ]; then
+            if echo "$output" | grep -qE 'EPUBLISHCONFLICT|E409|cannot publish over|already published'; then
+              echo "::notice::Tolerating 'already published' error for @aictrl/plugin"
+            else
+              exit $code
+            fi
+          fi
 
       - name: Publish @aictrl/sdk
         working-directory: packages/sdk
-        run: bun pm pack && npm publish *.tgz --access public --provenance || true
+        run: |
+          # See @aictrl/util step for wrapper rationale (issue #51).
+          bun pm pack
+          tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
+          if [ -z "$tarball" ]; then
+            echo "::error::bun pm pack produced no .tgz files in $(pwd)"
+            exit 1
+          fi
+          set +e
+          output=$(npm publish "$tarball" --access public --provenance 2>&1)
+          code=$?
+          set -e
+          echo "$output"
+          if [ $code -ne 0 ]; then
+            if echo "$output" | grep -qE 'EPUBLISHCONFLICT|E409|cannot publish over|already published'; then
+              echo "::notice::Tolerating 'already published' error for @aictrl/sdk"
+            else
+              exit $code
+            fi
+          fi
 
       - name: Publish platform binary packages
         working-directory: packages/cli/dist/@aictrl
         run: |
-          # Publish every @aictrl/cli-<platform>-<arch>[-variant] package that the
-          # build step produced. Each directory contains a generated package.json
-          # stamped with the release version. Individual failures (e.g. version
-          # already published on a rerun) are tolerated to match the convention
-          # used by the other publish steps in this workflow.
-          for dir in */; do
-            echo "Publishing ${dir%/}"
-            (cd "$dir" && npm publish --access public --provenance) || true
+          # Publish every @aictrl/cli-<platform>-<arch>[-variant] package that
+          # the build step produced. Each directory contains a generated
+          # package.json stamped with the release version. Individual
+          # "already published" errors are tolerated (for reruns), but every
+          # other failure - ENEEDAUTH, network, etc - fails loud. See #51.
+          shopt -s nullglob
+          dirs=(*/)
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "::error::No platform binary package directories found in $(pwd)"
+            exit 1
+          fi
+          for dir in "${dirs[@]}"; do
+            name="${dir%/}"
+            echo "Publishing ${name}"
+            set +e
+            output=$(cd "$dir" && npm publish --access public --provenance 2>&1)
+            code=$?
+            set -e
+            echo "$output"
+            if [ $code -ne 0 ]; then
+              if echo "$output" | grep -qE 'EPUBLISHCONFLICT|E409|cannot publish over|already published'; then
+                echo "::notice::Tolerating 'already published' error for ${name}"
+              else
+                exit $code
+              fi
+            fi
           done
 
       - name: Strip bundled deps and refresh platform binary optionalDependencies
@@ -133,4 +213,23 @@ jobs:
 
       - name: Publish @aictrl/cli
         working-directory: packages/cli
-        run: bun pm pack && npm publish *.tgz --access public --provenance
+        run: |
+          # See @aictrl/util step for wrapper rationale (issue #51).
+          bun pm pack
+          tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
+          if [ -z "$tarball" ]; then
+            echo "::error::bun pm pack produced no .tgz files in $(pwd)"
+            exit 1
+          fi
+          set +e
+          output=$(npm publish "$tarball" --access public --provenance 2>&1)
+          code=$?
+          set -e
+          echo "$output"
+          if [ $code -ne 0 ]; then
+            if echo "$output" | grep -qE 'EPUBLISHCONFLICT|E409|cannot publish over|already published'; then
+              echo "::notice::Tolerating 'already published' error for @aictrl/cli"
+            else
+              exit $code
+            fi
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,7 @@ jobs:
           # partial failure still succeed. Every other error - ENEEDAUTH,
           # network, etc - must fail loud. See issue #51 for the v0.3.1 /
           # v0.3.2 silent-failure post-mortem that motivated this wrapper.
+          rm -f *.tgz
           bun pm pack
           tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
           if [ -z "$tarball" ]; then
@@ -83,6 +84,7 @@ jobs:
         working-directory: packages/plugin
         run: |
           # See @aictrl/util step for wrapper rationale (issue #51).
+          rm -f *.tgz
           bun pm pack
           tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
           if [ -z "$tarball" ]; then
@@ -106,6 +108,7 @@ jobs:
         working-directory: packages/sdk
         run: |
           # See @aictrl/util step for wrapper rationale (issue #51).
+          rm -f *.tgz
           bun pm pack
           tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
           if [ -z "$tarball" ]; then
@@ -215,6 +218,7 @@ jobs:
         working-directory: packages/cli
         run: |
           # See @aictrl/util step for wrapper rationale (issue #51).
+          rm -f *.tgz
           bun pm pack
           tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
           if [ -z "$tarball" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,80 +53,15 @@ jobs:
 
       - name: Publish @aictrl/util
         working-directory: packages/util
-        run: |
-          # Pack, then publish the resulting tarball. We tolerate ONLY the
-          # "version already published" error (EPUBLISHCONFLICT / E409 /
-          # "cannot publish over" / "already published") so reruns after a
-          # partial failure still succeed. Every other error - ENEEDAUTH,
-          # network, etc - must fail loud. See issue #51 for the v0.3.1 /
-          # v0.3.2 silent-failure post-mortem that motivated this wrapper.
-          rm -f *.tgz
-          bun pm pack
-          tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
-          if [ -z "$tarball" ]; then
-            echo "::error::bun pm pack produced no .tgz files in $(pwd)"
-            exit 1
-          fi
-          set +e
-          output=$(npm publish "$tarball" --access public --provenance 2>&1)
-          code=$?
-          set -e
-          echo "$output"
-          if [ $code -ne 0 ]; then
-            if echo "$output" | grep -qE 'EPUBLISHCONFLICT|E409|cannot publish over|already published'; then
-              echo "::notice::Tolerating 'already published' error for @aictrl/util"
-            else
-              exit $code
-            fi
-          fi
+        run: ${{ github.workspace }}/.github/scripts/publish-if-new.sh "@aictrl/util"
 
       - name: Publish @aictrl/plugin
         working-directory: packages/plugin
-        run: |
-          # See @aictrl/util step for wrapper rationale (issue #51).
-          rm -f *.tgz
-          bun pm pack
-          tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
-          if [ -z "$tarball" ]; then
-            echo "::error::bun pm pack produced no .tgz files in $(pwd)"
-            exit 1
-          fi
-          set +e
-          output=$(npm publish "$tarball" --access public --provenance 2>&1)
-          code=$?
-          set -e
-          echo "$output"
-          if [ $code -ne 0 ]; then
-            if echo "$output" | grep -qE 'EPUBLISHCONFLICT|E409|cannot publish over|already published'; then
-              echo "::notice::Tolerating 'already published' error for @aictrl/plugin"
-            else
-              exit $code
-            fi
-          fi
+        run: ${{ github.workspace }}/.github/scripts/publish-if-new.sh "@aictrl/plugin"
 
       - name: Publish @aictrl/sdk
         working-directory: packages/sdk
-        run: |
-          # See @aictrl/util step for wrapper rationale (issue #51).
-          rm -f *.tgz
-          bun pm pack
-          tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
-          if [ -z "$tarball" ]; then
-            echo "::error::bun pm pack produced no .tgz files in $(pwd)"
-            exit 1
-          fi
-          set +e
-          output=$(npm publish "$tarball" --access public --provenance 2>&1)
-          code=$?
-          set -e
-          echo "$output"
-          if [ $code -ne 0 ]; then
-            if echo "$output" | grep -qE 'EPUBLISHCONFLICT|E409|cannot publish over|already published'; then
-              echo "::notice::Tolerating 'already published' error for @aictrl/sdk"
-            else
-              exit $code
-            fi
-          fi
+        run: ${{ github.workspace }}/.github/scripts/publish-if-new.sh "@aictrl/sdk"
 
       - name: Publish platform binary packages
         working-directory: packages/cli/dist/@aictrl
@@ -216,24 +151,4 @@ jobs:
 
       - name: Publish @aictrl/cli
         working-directory: packages/cli
-        run: |
-          # See @aictrl/util step for wrapper rationale (issue #51).
-          rm -f *.tgz
-          bun pm pack
-          tarball=$(ls -1 *.tgz 2>/dev/null | head -n1)
-          if [ -z "$tarball" ]; then
-            echo "::error::bun pm pack produced no .tgz files in $(pwd)"
-            exit 1
-          fi
-          set +e
-          output=$(npm publish "$tarball" --access public --provenance 2>&1)
-          code=$?
-          set -e
-          echo "$output"
-          if [ $code -ne 0 ]; then
-            if echo "$output" | grep -qE 'EPUBLISHCONFLICT|E409|cannot publish over|already published'; then
-              echo "::notice::Tolerating 'already published' error for @aictrl/cli"
-            else
-              exit $code
-            fi
-          fi
+        run: ${{ github.workspace }}/.github/scripts/publish-if-new.sh "@aictrl/cli"


### PR DESCRIPTION
## Summary
- Replaces unconditional `|| true` after every `npm publish` step in `publish.yml` with a wrapper that exits non-zero unless the npm output matches a known "version already published" pattern (`EPUBLISHCONFLICT`, `E409`, `cannot publish over`, `already published`)
- Fails loud if `bun pm pack` produces zero `.tgz` files (previously the glob-based invocation silently no-op'd)
- Applies the same wrapper to the final `@aictrl/cli` step for consistency and to cover the glob edge-case

## Why
The `|| true` approach silently masked ENEEDAUTH cascades during the v0.3.1 silent failure (2026-04-03) and the v0.3.2 release saga (2026-04-11). 14 publishes in a single run failed to auth and the workflow still reported all green except the very last step.

## Test plan
- [ ] Manual: trigger a workflow_dispatch and confirm it succeeds when nothing has changed (the rerun-tolerance path should still work)
- [ ] Manual: confirm CI annotation still surfaces individual step failures rather than only the final step
- [ ] Next real release goes out cleanly

## Conflict note
PR #55 (Node 20 action bumps) also touches `publish.yml`. Whichever lands second will need a rebase - expected.

Closes #51

Generated with [Claude Code](https://claude.com/claude-code)