### PR TITLE
chore: bump @aictrl/cli to 0.3.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "name": "@aictrl/cli",
   "description": "Headless execution engine for AI agent skills",
   "type": "module",


### PR DESCRIPTION
Patch bump ahead of the v0.3.3 release tag. Picks up #64 (NDJSON schema v1 for downstream consumers).

## Test plan
- [ ] CI green (build + typecheck + test)
- [ ] After merge: \`gh release create v0.3.3 --generate-notes\` to trigger publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)