### PR TITLE
fix(run): exit non-zero on session.error so CI wrappers see failures

### DIFF
--- a/packages/cli/src/cli/cmd/run.ts
+++ b/packages/cli/src/cli/cmd/run.ts
@@ -566,6 +566,11 @@ export const RunCommand = cmd({
             }
             if (props.sessionID === sessionID) {
               error = error ? error + EOL + err : err
+              // #70: propagate primary-session failures (auth, provider, retries-exhausted)
+              // to a non-zero exit code so CI wrappers see the failure instead of a
+              // spuriously-green job. process.exitCode (not process.exit) lets the
+              // loop drain to session.status idle and emit session_complete first.
+              process.exitCode = 1
             }
             if (emit("error", { error: props.error, sourceSessionID: props.sessionID })) continue
             UI.error(err)

--- a/packages/cli/test/cli/run-session-error-exit.test.ts
+++ b/packages/cli/test/cli/run-session-error-exit.test.ts
@@ -1,0 +1,50 @@
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+const RUN_SRC = path.resolve(import.meta.dir, "../../src/cli/cmd/run.ts")
+
+// Regression lock for aictrl-dev/cli#70:
+//   `aictrl run` was exiting 0 even when the provider rejected authentication.
+//   Root cause: the run-command's `session.error` event handler logged the
+//   error but did not set `process.exitCode`, so the subsequent
+//   `session.status: idle` broke the loop into the success branch and the
+//   process terminated with code 0 — masking broken CI workflows wrapping it.
+describe("run.ts session.error → non-zero exit (#70)", () => {
+  test("session.error handler sets process.exitCode for the primary session", async () => {
+    const source = await Bun.file(RUN_SRC).text()
+    const handlerIdx = source.indexOf('if (event.type === "session.error")')
+    expect(handlerIdx).toBeGreaterThan(-1)
+
+    // Bound the block to the next `if (event.type === ` so we only inspect
+    // this handler — not whatever happens to follow it in source.
+    const after = source.slice(handlerIdx + 1)
+    const nextHandlerOffset = after.indexOf('if (event.type === "')
+    const handlerBlock =
+      nextHandlerOffset === -1 ? after : after.slice(0, nextHandlerOffset)
+
+    // The handler must mark the process as failed. Either form is acceptable:
+    //   - process.exitCode = N (preferred — lets loop drain cleanly)
+    //   - process.exit(N)
+    const setsExitCode =
+      /process\.exitCode\s*=\s*[1-9]/.test(handlerBlock) ||
+      /process\.exit\s*\(\s*[1-9]/.test(handlerBlock)
+    expect(setsExitCode).toBe(true)
+  })
+
+  test("exit propagation is gated on the primary session, not subagents", async () => {
+    // A subagent's session.error must NOT take the whole process down;
+    // only the primary session's failure should propagate to the exit code.
+    const source = await Bun.file(RUN_SRC).text()
+    const handlerIdx = source.indexOf('if (event.type === "session.error")')
+    const after = source.slice(handlerIdx + 1)
+    const nextHandlerOffset = after.indexOf('if (event.type === "')
+    const handlerBlock =
+      nextHandlerOffset === -1 ? after : after.slice(0, nextHandlerOffset)
+
+    // The block must reference the primary `sessionID` check before exit propagation —
+    // the existing handler already gates the local `error` string on
+    // `props.sessionID === sessionID`, and the exit propagation must use the
+    // same gate.
+    expect(handlerBlock).toContain("props.sessionID === sessionID")
+  })
+})


### PR DESCRIPTION
## Summary

- `aictrl run`'s `session.error` handler in `run.ts` logged the error and stashed it into a local string but never set `process.exitCode` — so when the model session subsequently emitted `session.status: idle`, the run loop broke into the success branch and the process exited 0.
- Result: any CI workflow wrapping `aictrl run` shows step `conclusion: success` while the actual work (review, agent invocation, etc.) silently failed.
- Fix: set `process.exitCode = 1` when `session.error` fires for the *primary* session (sub-agent failures keep their existing behavior). Uses `exitCode` rather than `process.exit()` so `session_complete` still emits before termination.

## Root cause

`packages/cli/src/cli/cmd/run.ts:559-572` — the handler block only updated the local `error` accumulator string and called `UI.error()`. It did not propagate to the process exit code, so the success branch of `loopDone.then(...)` (line 703) ran on every error.

Trace for the auth-failure case observed in production:

1. Provider returns 401/403.
2. `session/processor.ts:388` publishes `session.error`, sets status `idle`.
3. `run.ts:559` handler logs but doesn't touch `exitCode`.
4. `run.ts:614` `session.status idle` breaks the loop.
5. `run.ts:703` success branch — emits `session_complete`, returns.
6. Process exits 0.

The neighboring error paths (`promptResult.catch` at line 768, `loopDone.catch` at line 721) already set `exitCode = 1` for synchronous failures; the `session.error` event path was the only gap.

## Reproduction (from aictrl-dev/aictrl#2058 investigation)

```bash
ZHIPU_API_KEY=invalid aictrl run --model zai-coding-plan/glm-5.1 -f some-skill.md -- "hello"
# stdout: "Error: Authentication Failed"
# echo $?      → 0   ← bug
```

After the fix: exit `1`.

## Test plan

- [x] New regression test (`packages/cli/test/cli/run-session-error-exit.test.ts`) — static lock asserting the handler block sets a non-zero exit code, mirroring the existing `run-event-race.test.ts` anti-pattern-lock style. Fails on `origin/main` (verified locally), passes on this branch.
- [x] Existing CLI command tests still pass (`bun test test/cli/` — 69/69).
- [x] Existing tool/skill tests pass in isolation; full-suite flakes are pre-existing and unrelated (verified by stashing the change).
- [x] `bun typecheck` passes.

## Acceptance criteria (from #70)

- [x] `aictrl run` with an invalid `ZHIPU_API_KEY` exits non-zero — flows through `session.error` for primary session → `exitCode = 1`
- [x] `aictrl run` with a network failure to the provider exits non-zero — same path (provider-side error → `MessageV2.fromError` → `Session.Event.Error`)
- [x] Existing happy-path tests still pass — no change to the success branch
- [x] Regression test asserting non-zero exit on auth failure

## Related

- aictrl-dev/aictrl#2058 — parent prod investigation that surfaced this CLI bug
- aictrl-dev/cli#4 — broader exit-code convention. This fix uses `1` as a reasonable baseline; if #4 lands a structured convention, the constant can be aligned then without redesigning the propagation path.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)