### PR TITLE
fix(publish): resolve catalog:/workspace:* protocols + use npm pack

### DIFF
--- a/.github/scripts/publish-if-new.sh
+++ b/.github/scripts/publish-if-new.sh
@@ -6,12 +6,25 @@
 # etc) fails loud. See issue #51 for the v0.3.1 / v0.3.2 silent-failure
 # post-mortem that motivated this wrapper.
 #
+# Also resolves Bun-only protocols (`catalog:` and `workspace:`) to
+# concrete semver before packing, so the published tarball is installable
+# via plain `npm install`. See issue #72 for the v0.3.3 install-failure
+# post-mortem that motivated this resolver.
+#
 # Usage:
 #   .github/scripts/publish-if-new.sh <package-label>
 #
-# Must be run from the package's working directory (where bun pm pack
-# will produce the .tgz). The <package-label> is used only for log
-# annotations (e.g. "@aictrl/util").
+# Env:
+#   REPO_ROOT       — absolute path to repo root (where workspaces.catalog
+#                     is defined). Defaults to `git rev-parse --show-toplevel`.
+#   AICTRL_VERSION  — release version with no `v` prefix. Used to substitute
+#                     `workspace:*` deps. Required only if the package being
+#                     published actually has workspace deps after any prior
+#                     strip step has run.
+#
+# Must be run from the package's working directory (where `npm pack` will
+# produce the .tgz). The <package-label> is used only for log annotations
+# (e.g. "@aictrl/util").
 
 set -euo pipefail
 
@@ -20,7 +33,55 @@ label="${1:?Usage: publish-if-new.sh <package-label>}"
 # Clean stale tarballs so we always publish the freshly packed one.
 rm -f *.tgz
 
-bun pm pack
+# Resolve Bun-only protocols (`catalog:`, `workspace:`) to concrete semver
+# before packing. Plain `npm install` rejects both with EUNSUPPORTEDPROTOCOL,
+# so any tarball that ships them is broken for npm consumers (and the AI
+# Review workflow in this very repo). #72.
+export REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+export AICTRL_VERSION="${AICTRL_VERSION:-}"
+node -e "
+  const fs = require('fs');
+  const path = require('path');
+  const root = JSON.parse(fs.readFileSync(path.join(process.env.REPO_ROOT, 'package.json'), 'utf8'));
+  const catalog = (root.workspaces && root.workspaces.catalog) || {};
+  const release = process.env.AICTRL_VERSION || '';
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  const fields = ['dependencies', 'optionalDependencies', 'peerDependencies', 'devDependencies'];
+  let touched = false;
+  for (const field of fields) {
+    const deps = pkg[field];
+    if (!deps) continue;
+    for (const [name, version] of Object.entries(deps)) {
+      if (version === 'catalog:') {
+        if (!catalog[name]) {
+          console.error('::error::' + field + '[' + name + '] is catalog: but root workspaces.catalog has no entry for it');
+          process.exit(1);
+        }
+        deps[name] = catalog[name];
+        touched = true;
+      } else if (typeof version === 'string' && version.startsWith('workspace:')) {
+        if (!release) {
+          console.error('::error::' + field + '[' + name + '] is ' + version + ' but AICTRL_VERSION env var is not set');
+          process.exit(1);
+        }
+        // All sibling @aictrl/* packages release in lockstep with AICTRL_VERSION.
+        // If that ever stops being true, replace with a per-package lookup.
+        deps[name] = release;
+        touched = true;
+      }
+    }
+  }
+  if (touched) {
+    fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+    console.log('::notice::resolved Bun-only protocol deps in ' + pkg.name + '@' + pkg.version);
+  }
+"
+
+# `npm pack` reads only the on-disk package.json, unlike `bun pm pack` which
+# re-injects workspace deps from the lockfile and silently ignores in-place
+# manifest edits (publish.yml's "Strip bundled deps" step had no effect on
+# v0.3.3 for this reason). #72.
+npm pack
 
 # Use nullglob array to avoid pipefail exit on no matches (ls *.tgz
 # returns exit 2 when nothing matches, which pipefail propagates).
@@ -29,12 +90,12 @@ tarballs=(*.tgz)
 shopt -u nullglob
 
 if [ ${#tarballs[@]} -eq 0 ]; then
-  echo "::error::bun pm pack produced no .tgz files in $(pwd)"
+  echo "::error::npm pack produced no .tgz files in $(pwd)"
   exit 1
 fi
 
 if [ ${#tarballs[@]} -gt 1 ]; then
-  echo "::warning::bun pm pack produced ${#tarballs[@]} .tgz files in $(pwd), publishing first: ${tarballs[0]}"
+  echo "::warning::npm pack produced ${#tarballs[@]} .tgz files in $(pwd), publishing first: ${tarballs[0]}"
 fi
 
 tarball="${tarballs[0]}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,10 @@ jobs:
           AICTRL_VERSION: ${{ github.event.release.tag_name }}
         run: |
           export AICTRL_VERSION="${AICTRL_VERSION#v}"
+          # Expose stripped version to subsequent steps so the publish-if-new.sh
+          # catalog:/workspace: resolver (and the smoke test below) can see it
+          # without each step re-doing the v-prefix strip. #72.
+          echo "AICTRL_VERSION=$AICTRL_VERSION" >> "$GITHUB_ENV"
           bun turbo build
 
       - name: Publish @aictrl/util
@@ -153,3 +157,35 @@ jobs:
       - name: Publish @aictrl/cli
         working-directory: packages/cli
         run: ${{ github.workspace }}/.github/scripts/publish-if-new.sh "@aictrl/cli"
+
+      - name: Smoke test - verify @aictrl/cli installs cleanly via npm
+        # Catches the v0.3.3-class bug where the published manifest carries
+        # Bun-only protocols (workspace:*, catalog:) that plain `npm install`
+        # rejects with EUNSUPPORTEDPROTOCOL. Without this gate, a broken
+        # publish goes unnoticed until consumers report install failures.
+        # #72.
+        run: |
+          set -euo pipefail
+          smoke="${RUNNER_TEMP}/aictrl-publish-smoke"
+          rm -rf "$smoke"
+          mkdir -p "$smoke"
+          cd "$smoke"
+          npm init -y > /dev/null
+
+          # CDN propagation can lag ~30-60s after publish; retry briefly.
+          for attempt in 1 2 3 4 5; do
+            if npm install "@aictrl/cli@${AICTRL_VERSION}" 2>&1 | tee install.log; then
+              echo "::notice::npm install @aictrl/cli@${AICTRL_VERSION} succeeded on attempt ${attempt}"
+              exit 0
+            fi
+            # EUNSUPPORTEDPROTOCOL means the resolver in publish-if-new.sh
+            # didn't catch a workspace:/catalog: leak. Retrying won't help.
+            if grep -q "EUNSUPPORTEDPROTOCOL" install.log; then
+              echo "::error::@aictrl/cli@${AICTRL_VERSION} ships protocol-prefixed deps that plain npm cannot resolve. The catalog:/workspace: resolver in publish-if-new.sh did not run or did not cover all fields. See aictrl-dev/cli#72."
+              exit 1
+            fi
+            echo "::warning::install attempt ${attempt} failed (likely CDN propagation), retrying in 30s..."
+            sleep 30
+          done
+          echo "::error::npm install @aictrl/cli@${AICTRL_VERSION} failed after 5 attempts"
+          exit 1


### PR DESCRIPTION
## Summary

The publish pipeline shipped \`@aictrl/cli@0.3.3\` with unresolved \`workspace:*\` deps and \`@aictrl/util@1.2.16\` with unresolved \`catalog:\` deps. Both are Bun-only protocols — plain \`npm install\` rejects them with \`EUNSUPPORTEDPROTOCOL\`. This silently broke the AI Review workflow on every PR for ~4 weeks (#72) and any downstream npm consumer.

## Root cause

Two interacting bugs:

1. **\`bun pm pack\` ignores in-place package.json edits.** \`publish.yml\`'s "Strip bundled deps" step ran a \`node -e ...\` that deleted \`pkg.dependencies\`, \`pkg.devDependencies\`, \`pkg.peerDependencies\`, \`pkg.exports\`, and \`pkg.type\` before pack — but every one of those fields survived to the published tarball. Verified by extracting \`aictrl-cli-0.3.3.tgz\` and inspecting its \`package.json\`: \`type\`, \`exports\`, \`dependencies\` (with \`workspace:*\`), \`devDependencies\`, \`peerDependencies\` all present. \`bun pm pack\` reads workspace deps from the workspace lockfile/manifest snapshot, not from the on-disk \`package.json\`.

2. **No \`catalog:\` resolver anywhere in the pipeline.** \`@aictrl/util\` ships \`{ zod: 'catalog:' }\` because the strip-everything approach (only run on CLI) doesn't apply to packages that actually need runtime deps. The \`catalog:\` protocol comes from Bun's centralized version pinning; npm has no equivalent and rejects it.

Evidence:

\`\`\`bash
$ npm view @aictrl/cli@0.3.3 dependencies
{ '@aictrl/plugin': 'workspace:*', '@aictrl/sdk': 'workspace:*', '@aictrl/util': 'workspace:*', ... }

$ npm view @aictrl/util@latest dependencies
{ zod: 'catalog:' }

$ npm install @aictrl/cli@latest
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type \"workspace:\": workspace:*
\`\`\`

## Fix

### \`publish-if-new.sh\`

- Add a **catalog:/workspace: resolver** before pack. Reads root \`package.json > workspaces.catalog\` for catalog deps, uses \`AICTRL_VERSION\` env for sibling workspace deps. Covers \`dependencies\`, \`optionalDependencies\`, \`peerDependencies\`, \`devDependencies\` fields.
- **Fail-loud** if a catalog dep has no catalog entry, or if \`workspace:*\` is hit without \`AICTRL_VERSION\`. No silent fallback.
- **Replace \`bun pm pack\` with \`npm pack\`** — \`npm pack\` reads only the on-disk \`package.json\`, so both the resolver above and the existing "Strip bundled deps" step in \`publish.yml\` actually take effect.

### \`publish.yml\`

- In **Build Packages**, expose stripped \`AICTRL_VERSION\` (no \`v\` prefix) to subsequent steps via \`\$GITHUB_ENV\` so the resolver can see it. One-line change.
- New **post-publish smoke test step**: in a scratch dir on the runner, \`npm install @aictrl/cli@\$AICTRL_VERSION\`, with CDN-aware retry (5 × 30s). Fails loud on \`EUNSUPPORTEDPROTOCOL\` immediately (no retry — won't help). Catches the entire bug class.

## Local verification

Resolver against \`packages/util/package.json\`:
\`\`\`
\"zod\": \"catalog:\"        → \"zod\": \"4.1.8\"        ✓
\"typescript\": \"catalog:\" → \"typescript\": \"5.8.2\" ✓
\"@types/bun\": \"catalog:\" → \"@types/bun\": \"1.3.9\" ✓
\`\`\`

Resolver against \`v0.3.3:packages/cli/package.json\` with \`AICTRL_VERSION=0.3.4\`:
\`\`\`
\"@aictrl/plugin\": \"workspace:*\" → \"0.3.4\" ✓
\"@aictrl/sdk\": \"workspace:*\"    → \"0.3.4\" ✓
\"@aictrl/util\": \"workspace:*\"   → \"0.3.4\" ✓
\"@octokit/rest\": \"catalog:\"     → resolved from root catalog ✓
\`\`\`
\`npm pack\` produced a valid \`aictrl-cli-0.3.3.tgz\`.

Fail-loud path verified: with \`AICTRL_VERSION\` unset on a CLI package.json that still has workspace deps, the resolver exits with \`::error::dependencies[@aictrl/plugin] is workspace:* but AICTRL_VERSION env var is not set\` and no tarball is produced.

## End-to-end validation plan

The publish workflow only runs on \`release: published\` events, so this can't be exercised in CI on the PR itself. Validation steps after merge:

1. Cut a release \`v0.3.4\` (just for this fix).
2. Watch the workflow logs:
   - \`::notice::resolved Bun-only protocol deps in @aictrl/util@1.2.16\` should appear.
   - Smoke test step should print \`::notice::npm install @aictrl/cli@0.3.4 succeeded on attempt N\` and exit green.
3. From any clean dir: \`mkdir /tmp/t && cd /tmp/t && npm init -y && npm install @aictrl/cli@0.3.4\` — should succeed.
4. (Recommended) \`npm deprecate @aictrl/cli@0.3.3 \"Broken: workspace:* deps, use 0.3.4+. See aictrl-dev/cli#72\"\` and same for \`@aictrl/util@1.2.16\` so existing \`@latest\` resolvers get a warning instead of a silent install failure.

Once 0.3.4 is on npm, the \`Aictrl AI Review\` workflow on this repo (which does \`npm install @aictrl/cli@latest\`) will start passing again.

## Test plan

- [x] Resolver outputs concrete semver for \`catalog:\` deps (verified against \`packages/util/package.json\`)
- [x] Resolver outputs concrete semver for \`workspace:*\` deps when \`AICTRL_VERSION\` is set (verified against v0.3.3 CLI manifest)
- [x] Resolver fails loud when a catalog dep has no catalog entry
- [x] Resolver fails loud on \`workspace:*\` without \`AICTRL_VERSION\`
- [x] \`npm pack\` produces a valid tarball after the resolver runs
- [x] YAML lint clean on the updated publish.yml
- [x] Bash syntax clean on the updated publish-if-new.sh
- [ ] End-to-end: smoke test passes on a real release cut (only verifiable on merge + tag)

## Related

- aictrl-dev/cli#72 — the parent bug
- aictrl-dev/cli#51 — sibling fix (fail-loud on \`npm publish\` auth errors); same theme of silent-failure publish bugs
- aictrl-dev/cli#71 — \`aictrl run\` exit-code fix; merged but currently un-installable due to #72
- aictrl-dev/aictrl#2058 — downstream impact (parent prod investigation; same AI Review workflow there)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)