### PR TITLE
chore: bump @aictrl/cli to 0.3.5 and @aictrl/util to 1.2.17

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "name": "@aictrl/cli",
   "description": "Headless execution engine for AI agent skills",
   "type": "module",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aictrl/util",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "private": false,
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

v0.3.4 release attempt didn't actually publish \`@aictrl/cli@0.3.4\` — the smoke test (added in #73) caught it: \`ETARGET: No matching version found for @aictrl/cli@0.3.4\`.

Root cause: \`publish.yml\` stamps \`AICTRL_VERSION\` (from \`release.tag_name\`) into platform binary manifests via \`Script.version\` in \`build.ts\`, but the main packages (\`@aictrl/cli\`, \`@aictrl/util\`, \`@aictrl/sdk\`) publish whatever's in their on-disk \`packages/<name>/package.json\` version. So on the v0.3.4 tag with \`cli/package.json\` still at \`0.3.3\`, the publish step packed and tried to publish \`@aictrl/cli@0.3.3\` — already on npm — and the workflow's "tolerate already-published" path said success.

This PR bumps the versions so v0.3.5 actually ships new \`@aictrl/cli\` and \`@aictrl/util\` versions carrying:

- **#71 fix**: \`aictrl run\` exit-non-zero on \`session.error\` (auth/provider failures)
- **#72 fix**: \`workspace:*\` and \`catalog:\` protocol resolver in the publish pipeline; switch from \`bun pm pack\` to \`npm pack\`

\`@aictrl/sdk\` not bumped: its \`catalog:\` deps are all in \`devDependencies\` (ignored by npm consumers at install time), so \`0.1.2\` is functionally installable. Bumping it would only matter for sdk-package developers cloning the repo.

## After this merges

```bash
git checkout main && git pull
git tag -a v0.3.5 -m \"v0.3.5: ship #71 + #72 fixes\"
git push origin v0.3.5
gh release create v0.3.5 --repo aictrl-dev/cli \
  --title \"v0.3.5\" \
  --notes \"#71: exit non-zero on auth/provider failures. #72: workspace:/catalog: protocol resolver in publish pipeline. Supersedes the partial v0.3.4 release.\"
```

The publish workflow should then:
- Stamp \`0.3.5\` into all platform binary manifests via \`Script.version\`.
- Run the catalog:/workspace: resolver against \`@aictrl/util@1.2.17\` and \`@aictrl/sdk@0.1.2\` before pack.
- Publish \`@aictrl/util@1.2.17\` (new — first version with resolved catalog: deps) and \`@aictrl/cli@0.3.5\` (new — first version with resolved workspace:* deps + the new exit-code propagation).
- Tolerate already-published for \`@aictrl/sdk@0.1.2\`.
- Smoke test: \`npm install @aictrl/cli@0.3.5\` should succeed.

## Follow-up worth filing

\`publish.yml\` should stamp \`AICTRL_VERSION\` into all package manifests, not just platform binaries — so future releases don't need manual version bumps in a separate PR. Out of scope for this one.

## Test plan

- [x] Diff is minimal — just the two version fields
- [ ] Verify check passes (typecheck + tests)
- [ ] CodeQL passes
- [ ] (Aictrl AI Review will fail until v0.3.5 actually lands on npm — chicken-and-egg, expected)

Refs #71 #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)