### PR TITLE
fix: preserve openai-compatible reasoning_effort option

### DIFF
--- a/packages/cli/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/cli/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -172,7 +172,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
           ),
         ),
 
-        reasoning_effort: compatibleOptions.reasoningEffort,
+        reasoning_effort: compatibleOptions.reasoning_effort ?? compatibleOptions.reasoningEffort,
         verbosity: compatibleOptions.textVerbosity,
 
         // messages:

--- a/packages/cli/src/provider/sdk/copilot/chat/openai-compatible-chat-options.ts
+++ b/packages/cli/src/provider/sdk/copilot/chat/openai-compatible-chat-options.ts
@@ -11,11 +11,13 @@ export const openaiCompatibleProviderOptions = z.object({
 
   /**
    * Reasoning effort for reasoning models. Defaults to `medium`.
+   * Alias of `reasoning_effort`; ignored when both are set.
    */
   reasoningEffort: z.string().optional(),
 
   /**
-   * OpenAI-compatible reasoning effort request field.
+   * OpenAI-compatible reasoning effort request field (wire name).
+   * Takes precedence over `reasoningEffort` when both are set.
    */
   reasoning_effort: z.string().optional(),
 

--- a/packages/cli/src/provider/sdk/copilot/chat/openai-compatible-chat-options.ts
+++ b/packages/cli/src/provider/sdk/copilot/chat/openai-compatible-chat-options.ts
@@ -15,6 +15,11 @@ export const openaiCompatibleProviderOptions = z.object({
   reasoningEffort: z.string().optional(),
 
   /**
+   * OpenAI-compatible reasoning effort request field.
+   */
+  reasoning_effort: z.string().optional(),
+
+  /**
    * Controls the verbosity of the generated text. Defaults to `medium`.
    */
   textVerbosity: z.string().optional(),

--- a/packages/cli/test/provider/copilot/copilot-chat-model.test.ts
+++ b/packages/cli/test/provider/copilot/copilot-chat-model.test.ts
@@ -589,4 +589,35 @@ describe("request body", () => {
       },
     ])
   })
+
+  test("should pass snake_case reasoning_effort provider option", async () => {
+    let capturedBody: unknown
+    const mockFetch = mock(async (_url: string, init?: RequestInit) => {
+      capturedBody = JSON.parse(init?.body as string)
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(`data: [DONE]\n\n`))
+            controller.close()
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      )
+    })
+
+    const model = createModel(mockFetch)
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        copilot: {
+          reasoningEffort: "high",
+          reasoning_effort: "none",
+        },
+      },
+      includeRawChunks: false,
+    })
+
+    expect((capturedBody as { reasoning_effort?: string }).reasoning_effort).toBe("none")
+  })
 })

--- a/packages/cli/test/provider/copilot/copilot-chat-model.test.ts
+++ b/packages/cli/test/provider/copilot/copilot-chat-model.test.ts
@@ -620,4 +620,64 @@ describe("request body", () => {
 
     expect((capturedBody as { reasoning_effort?: string }).reasoning_effort).toBe("none")
   })
+
+  test("should pass reasoning_effort when set alone", async () => {
+    let capturedBody: unknown
+    const mockFetch = mock(async (_url: string, init?: RequestInit) => {
+      capturedBody = JSON.parse(init?.body as string)
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(`data: [DONE]\n\n`))
+            controller.close()
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      )
+    })
+
+    const model = createModel(mockFetch)
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        copilot: {
+          reasoning_effort: "none",
+        },
+      },
+      includeRawChunks: false,
+    })
+
+    expect((capturedBody as { reasoning_effort?: string }).reasoning_effort).toBe("none")
+  })
+
+  test("should fall back to camelCase reasoningEffort when snake_case is absent", async () => {
+    let capturedBody: unknown
+    const mockFetch = mock(async (_url: string, init?: RequestInit) => {
+      capturedBody = JSON.parse(init?.body as string)
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(`data: [DONE]\n\n`))
+            controller.close()
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      )
+    })
+
+    const model = createModel(mockFetch)
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        copilot: {
+          reasoningEffort: "high",
+        },
+      },
+      includeRawChunks: false,
+    })
+
+    expect((capturedBody as { reasoning_effort?: string }).reasoning_effort).toBe("high")
+  })
 })


### PR DESCRIPTION
## Summary

Addresses the snake_case provider-option path from #75.

`@ai-sdk/openai-compatible` request construction filtered `reasoning_effort` out of provider options because only `reasoningEffort` was in the parsed schema, then wrote `reasoning_effort` from the camelCase value. That made an explicit `reasoning_effort: "none"` no-op for OpenAI-compatible endpoints such as Ollama's `/v1/chat/completions`.

This change:

- accepts `reasoning_effort` in the openai-compatible provider options schema
- writes the OpenAI-compatible request body from `reasoning_effort ?? reasoningEffort`
- adds request-body regression coverage showing snake_case wins when both forms are present

## Validation

- `bun test test/provider/copilot/copilot-chat-model.test.ts`
- `bun run typecheck`
- `git diff --check`

