### PR TITLE
chore: bump @aictrl/cli to 0.3.6

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "name": "@aictrl/cli",
   "description": "Headless execution engine for AI agent skills",
   "type": "module",


### PR DESCRIPTION
Bump @aictrl/cli 0.3.5 -> 0.3.6 ahead of the v0.3.6 release so the publish workflow actually publishes a new CLI version (it does not stamp AICTRL_VERSION into the main manifest — see #74).

Carries #76 (preserve openai-compatible reasoning_effort option).

util and sdk are unchanged since v0.3.5 and are not bumped; their publish steps will tolerate already-published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)