### PR TITLE
chore: bump @aictrl/cli to 0.4.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "name": "@aictrl/cli",
   "description": "Headless execution engine for AI agent skills",
   "type": "module",


### PR DESCRIPTION
## Summary
Bump `@aictrl/cli` from `0.3.7` to `0.4.0` for the GLM-5.2 minor release.

## Issues addressed
- Updates the CLI package minor version after GLM-5.2 harness support merged in #82.

## Verified false
- None.

## Not addressed
- No runtime code changes.

## Test plan
- [x] `bun run typecheck` from `packages/cli`
- [x] `git diff --check`
- [x] pre-push `bun turbo typecheck`

<!-- review-verdicts
{
  "sourcePR": 82,
  "analyzedAt": null,
  "findings": []
}
-->