### PR TITLE
docs: add model version bump guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+- For model-only support changes, use a patch version bump. Example: adding a new model after `0.3.7` should bump to `0.3.8`, not `0.4.0`.
+- Reserve minor version bumps for broader feature or compatibility changes, not routine model catalog/provider additions.


### PR DESCRIPTION
## Summary
Add repo-local Claude guidance that model-only support changes should use patch version bumps, not minor version jumps.

## Issues addressed
- Documents that adding a model after `0.3.7` should bump to `0.3.8`, not `0.4.0`.

## Verified false
- None.

## Not addressed
- Does not change current package versions or release state.

## Test plan
- [x] pre-push `bun turbo typecheck`

<!-- review-verdicts
{
  "sourcePR": null,
  "analyzedAt": null,
  "findings": []
}
-->